### PR TITLE
[DOP-37650] Drop pydantic.v1 imports

### DIFF
--- a/onetl/connection/db_connection/dialect_mixins/not_support_hint.py
+++ b/onetl/connection/db_connection/dialect_mixins/not_support_hint.py
@@ -15,4 +15,4 @@ class NotSupportHint:
     ) -> None:
         if hint is not None:
             msg = f"'hint' parameter is not supported by {self.connection.__class__.__name__}"
-            raise TypeError(msg)
+            raise ValueError(msg)

--- a/onetl/connection/db_connection/dialect_mixins/not_support_where.py
+++ b/onetl/connection/db_connection/dialect_mixins/not_support_where.py
@@ -15,4 +15,4 @@ class NotSupportWhere:
     ) -> None:
         if where is not None:
             msg = f"'where' parameter is not supported by {self.connection.__class__.__name__}"
-            raise TypeError(msg)
+            raise ValueError(msg)

--- a/onetl/connection/db_connection/dialect_mixins/support_hint_str.py
+++ b/onetl/connection/db_connection/dialect_mixins/support_hint_str.py
@@ -21,6 +21,6 @@ class SupportHintStr:
                 f"{self.connection.__class__.__name__} requires 'hint' parameter type to be 'str', "
                 f"got {hint.__class__.__name__!r}"
             )
-            raise TypeError(msg)
+            raise ValueError(msg)  # noqa: TRY004
 
         return hint

--- a/onetl/connection/db_connection/dialect_mixins/support_hwm_expression_str.py
+++ b/onetl/connection/db_connection/dialect_mixins/support_hwm_expression_str.py
@@ -20,6 +20,6 @@ class SupportHWMExpressionStr:
                 f"{self.connection.__class__.__name__} requires 'hwm.expression' parameter type to be 'str', "
                 f"got {hwm.expression.__class__.__name__!r}"
             )
-            raise TypeError(msg)
+            raise ValueError(msg)  # noqa: TRY004
 
         return hwm

--- a/onetl/connection/db_connection/dialect_mixins/support_where_str.py
+++ b/onetl/connection/db_connection/dialect_mixins/support_where_str.py
@@ -21,6 +21,6 @@ class SupportWhereStr:
                 f"{self.connection.__class__.__name__} requires 'where' parameter type to be 'str', "
                 f"got {where.__class__.__name__!r}"
             )
-            raise TypeError(msg)
+            raise ValueError(msg)  # noqa: TRY004
 
         return where

--- a/onetl/connection/db_connection/mongodb/dialect.py
+++ b/onetl/connection/db_connection/mongodb/dialect.py
@@ -76,7 +76,7 @@ class MongoDBDialect(
                 f"{self.connection.__class__.__name__} requires 'where' parameter type to be 'dict', "
                 f"got {where.__class__.__name__!r}"
             )
-            raise TypeError(msg)
+            raise ValueError(msg)  # noqa: TRY004
 
         for key in where:
             self._validate_top_level_keys_in_where_parameter(key)
@@ -94,7 +94,7 @@ class MongoDBDialect(
                 f"{self.connection.__class__.__name__} requires 'hint' parameter type to be 'dict', "
                 f"got {hint.__class__.__name__!r}"
             )
-            raise TypeError(msg)
+            raise ValueError(msg)  # noqa: TRY004
         return hint
 
     def prepare_pipeline(

--- a/onetl/core/file_filter/file_filter.py
+++ b/onetl/core/file_filter/file_filter.py
@@ -6,7 +6,7 @@ import re
 import textwrap
 import warnings
 
-from pydantic import ConfigDict, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 from typing_extensions import deprecated
 
 from onetl.base import BaseFileFilter, PathProtocol
@@ -86,8 +86,6 @@ class FileFilter(BaseFileFilter, FrozenModel):
     FileFilter()  # will raise ValueError, at least one argument should be passed
     ```
     """
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     glob: str | None = None
     regexp: re.Pattern | None = None

--- a/onetl/db/db_reader/db_reader.py
+++ b/onetl/db/db_reader/db_reader.py
@@ -7,15 +7,9 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import frozendict
-from etl_entities.hwm import HWM, ColumnHWM, KeyValueHWM
+from etl_entities.hwm import HWM, ColumnHWM, HWMTypeRegistry, KeyValueHWM
 from humanize import naturaldelta
-
-# using pydantic v1 for backward compatibility with etl-entities 3.x
-try:
-    from pydantic.v1 import BaseModel, Field, PrivateAttr, root_validator, validator
-except (ImportError, AttributeError):
-    from pydantic import BaseModel, Field, PrivateAttr, root_validator, validator  # type: ignore[no-redef, assignment]
-
+from pydantic import Field, PrivateAttr, ValidationInfo, field_validator, model_validator
 
 from onetl._util.alias import avoid_alias
 from onetl._util.process import get_process_info
@@ -28,7 +22,7 @@ from onetl.base import (
 from onetl.exception import NoDataError
 from onetl.hooks import slot, support_hooks
 from onetl.hwm import AutoDetectHWM, Edge, Window
-from onetl.impl import GenericOptions
+from onetl.impl import FrozenModel, GenericOptions
 from onetl.log import (
     entity_boundary_log,
     log_collection,
@@ -50,7 +44,7 @@ log = getLogger(__name__)
 
 
 @support_hooks
-class DBReader(BaseModel):
+class DBReader(FrozenModel):
     """Allows you to read data from a table with specified database connection
     and parameters, and return its content as Spark dataframe. [![support hooks](https://img.shields.io/badge/%20-support%20hooks-blue)](/hooks/)
 
@@ -308,24 +302,14 @@ class DBReader(BaseModel):
 
     connection: BaseDBConnection
     source: str = Field(alias=avoid_alias("table"))  # type: ignore[literal-required]
-    columns: list[str] | None = Field(default=None, min_items=1)
-    where: Any | None = None
-    hint: Any | None = None
-    df_schema: "StructType | None" = None
-    hwm_column: str | tuple[str, str] | None = Field(deprecated=True, default=None)
-    hwm_expression: str | None = Field(deprecated=True, default=None)
-    hwm: AutoDetectHWM | ColumnHWM | KeyValueHWM | None = None
-    options: GenericOptions | None = None
+    columns: list[str] | None = Field(default=None, min_length=1, validate_default=True)
+    where: Any | None = Field(default=None, validate_default=True)
+    hint: Any | None = Field(default=None, validate_default=True)
+    df_schema: "StructType | None" = Field(default=None, validate_default=True)
+    hwm: AutoDetectHWM | ColumnHWM | KeyValueHWM | None = Field(default=None, validate_default=True)
+    options: GenericOptions | None = Field(default=None, validate_default=True)
 
     AutoDetectHWM: ClassVar = AutoDetectHWM
-
-    class Config:
-        frozen = True
-        extra = "forbid"
-        smart_union = True
-        arbitrary_types_allowed = True
-        allow_population_by_field_name = True
-        underscore_attrs_are_private = True
 
     _connection_checked: bool = PrivateAttr(default=False)
 
@@ -334,59 +318,73 @@ class DBReader(BaseModel):
 
         from pyspark.sql.types import StructType
 
-        cls.update_forward_refs(StructType=StructType)
+        _ = StructType
+
+        cls.model_rebuild()
         return super().__new__(cls)
 
-    @validator("source", always=True)
-    def validate_source(cls, value: str, values):
-        if "connection" not in values:
+    @field_validator("source", mode="before")
+    @classmethod
+    def _validate_source(cls, value, info: ValidationInfo):
+        connection: BaseDBConnection | None = info.data.get("connection")
+        if not connection:
             return value
-        connection: BaseDBConnection = values["connection"]
         return connection.dialect.validate_name(value)
 
-    @validator("columns", always=True, pre=True)
-    def validate_columns(cls, value: str | list[str] | None, values: dict) -> list[str] | None:
-        if "connection" not in values:
-            return value  # type: ignore[return-value]
-        connection: BaseDBConnection = values["connection"]
+    @field_validator("columns", mode="before")
+    @classmethod
+    def _validate_columns(cls, value, info: ValidationInfo):
+        connection: BaseDBConnection | None = info.data.get("connection")
+        if not connection:
+            return value
         return connection.dialect.validate_columns(value)
 
-    @validator("where", always=True)
-    def validate_where(cls, value: Any, values: dict) -> Any:
-        if "connection" not in values:
-            return value  # type: ignore[return-value]
-        connection: BaseDBConnection = values["connection"]
+    @field_validator("where", mode="before")
+    @classmethod
+    def _validate_where(cls, value, info: ValidationInfo):
+        connection: BaseDBConnection | None = info.data.get("connection")
+        if not connection:
+            return value
         result = connection.dialect.validate_where(value)
         if isinstance(result, dict):
             return frozendict.frozendict(result)  # type: ignore[attr-defined, operator]
         return result
 
-    @validator("hint", always=True)
-    def validate_hint(cls, value: Any, values: dict) -> Any:
-        if "connection" not in values:
-            return value  # type: ignore[return-value]
-        connection: BaseDBConnection = values["connection"]
+    @field_validator("hint", mode="before")
+    @classmethod
+    def _validate_hint(cls, value, info: ValidationInfo):
+        connection: BaseDBConnection | None = info.data.get("connection")
+        if not connection:
+            return value
         result = connection.dialect.validate_hint(value)
         if isinstance(result, dict):
             return frozendict.frozendict(result)  # type: ignore[attr-defined, operator]
         return result
 
-    @validator("df_schema", always=True)
-    def validate_df_schema(cls, value: "StructType | None", values: dict) -> "StructType | None":
-        if "connection" not in values:
-            return value  # type: ignore[return-value]
-        connection: BaseDBConnection = values["connection"]
+    @field_validator("df_schema", mode="before")
+    @classmethod
+    def _validate_df_schema(cls, value, info: ValidationInfo):
+        connection: BaseDBConnection | None = info.data.get("connection")
+        if not connection:
+            return value
         return connection.dialect.validate_df_schema(value)
 
-    @root_validator(skip_on_failure=True)
-    def validate_hwm(cls, values: dict) -> dict:
-        connection: BaseDBConnection = values["connection"]
-        source: str = values["source"]
-        hwm_column: str | tuple[str, str] | None = values.get("hwm_column")
-        hwm_expression: str | None = values.get("hwm_expression")
+    @model_validator(mode="before")
+    @classmethod
+    def _deprecated_hwm_column_to_hwm(cls, values: dict) -> dict:
+        connection: BaseDBConnection | None = values.get("connection")
+        if not connection:
+            return values
+
+        source = values.get("source")
+        if not source:
+            return values
+
+        hwm_column: str | tuple[str, str] | None = values.pop("hwm_column", None)
+        hwm_expression: str | None = values.pop("hwm_expression", None)
         hwm: HWM | None = values.get("hwm")
 
-        if hwm_column is not None:
+        if hwm_column:
             if hwm:
                 msg = "Please pass either DBReader(hwm=...) or DBReader(hwm_column=...), not both"
                 raise ValueError(msg)
@@ -432,14 +430,35 @@ class DBReader(BaseModel):
                 expression=hwm_expression or hwm_column,
             )
 
-        if hwm and not hwm.expression:
+        values["hwm"] = hwm
+        return values
+
+    # etl-entities v1 uses pydantic v1 models
+    # which are not compatible with pydantic v2.
+    # using a plain validator here
+    @field_validator("hwm", mode="plain")
+    @classmethod
+    def _validate_hwm(cls, hwm, info: ValidationInfo):
+        if not hwm:
+            return None
+
+        if not isinstance(hwm, (ColumnHWM, KeyValueHWM, AutoDetectHWM)):
+            hwm = HWMTypeRegistry.parse(hwm)
+
+        if not isinstance(hwm, (ColumnHWM, KeyValueHWM, AutoDetectHWM)):
+            msg = f"Expected ColumnHWM or KeyValueHWM, got {hwm.__class__.__name__}"
+            raise ValueError(msg)  # noqa: TRY004
+
+        hwm = cast("ColumnHWM | KeyValueHWM | AutoDetectHWM", hwm)
+        if not hwm.expression:
             msg = "`hwm.expression` cannot be None"
             raise ValueError(msg)
 
-        if hwm and not hwm.entity:
+        source = info.data.get("source")
+        if not hwm.entity:
             hwm = hwm.copy(update={"entity": source})
 
-        if hwm and hwm.entity != source:
+        if hwm.entity != source:
             error_message = textwrap.dedent(
                 f"""
                 Passed `hwm.source` is different from `source`.
@@ -455,20 +474,25 @@ class DBReader(BaseModel):
             )
             raise ValueError(error_message)
 
-        values["hwm"] = connection.dialect.validate_hwm(hwm)
-        values["hwm_column"] = None
-        values["hwm_expression"] = None
-        return values
+        connection: BaseDBConnection | None = info.data.get("connection")
+        if not connection:
+            return hwm
 
-    @validator("options", pre=True, always=True)
-    def validate_options(cls, options, values):
-        connection = values.get("connection")
+        return connection.dialect.validate_hwm(hwm)
+
+    @field_validator("options", mode="before")
+    @classmethod
+    def _validate_options(cls, value, info: ValidationInfo):
+        connection: BaseDBConnection | None = info.data.get("connection")
+        if not connection:
+            return value
+
         read_options_class = getattr(connection, "ReadOptions", None)
         if read_options_class:
-            return read_options_class.parse(options)
+            return read_options_class.parse(value)
 
-        if options:
-            msg = f"{connection.__class__.__name__} does not implement ReadOptions, but {options!r} is passed"
+        if value:
+            msg = f"{connection.__class__.__name__} does not implement ReadOptions, but {value!r} is passed"
             raise ValueError(msg)
 
         return None

--- a/onetl/file/file_downloader/file_downloader.py
+++ b/onetl/file/file_downloader/file_downloader.py
@@ -9,18 +9,12 @@ import warnings
 from collections.abc import Generator, Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from enum import Enum
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 
-from etl_entities.hwm import FileHWM, FileListHWM
+from etl_entities.hwm import FileHWM, FileListHWM, HWMTypeRegistry
 from humanize import naturaldelta
 from ordered_set import OrderedSet
-
-# using pydantic v1 for backward compatibility with etl-entities 3.x
-try:
-    from pydantic.v1 import BaseModel, Field, PrivateAttr, root_validator, validator
-except (ImportError, AttributeError):
-    from pydantic import BaseModel, Field, PrivateAttr, root_validator, validator  # type: ignore[no-redef, assignment]
-
+from pydantic import Field, PrivateAttr, ValidationInfo, field_validator, model_validator
 
 from onetl._util.file import absolute_path, generate_temp_path
 from onetl._util.process import get_process_info
@@ -34,6 +28,7 @@ from onetl.hooks import slot, support_hooks
 from onetl.impl import (
     FailedRemoteFile,
     FileExistBehavior,
+    FrozenModel,
     LocalPath,
     RemoteFile,
     RemotePath,
@@ -65,7 +60,7 @@ class FileDownloadStatus(Enum):
 
 
 @support_hooks
-class FileDownloader(BaseModel):
+class FileDownloader(FrozenModel):
     """Allows you to download files from a remote source with specified file connection
     and parameters, and return an object with download result summary. [![support hooks](https://img.shields.io/badge/%20-support%20hooks-blue)](/hooks/)
 
@@ -268,18 +263,10 @@ class FileDownloader(BaseModel):
     filters: list[BaseFileFilter] = Field(default_factory=list, alias="filter")
     limits: list[BaseFileLimit] = Field(default_factory=list, alias="limit")
 
-    hwm: FileHWM | None = None
-    hwm_type: Any | None = Field(default=None, deprecated=True)
+    hwm: FileHWM | None = Field(default=None, validate_default=True)
 
     options: FileDownloaderOptions = FileDownloaderOptions()
     Options: ClassVar = FileDownloaderOptions
-
-    class Config:
-        frozen = True
-        extra = "forbid"
-        arbitrary_types_allowed = True
-        allow_population_by_field_name = True
-        underscore_attrs_are_private = True
 
     _connection_checked: bool = PrivateAttr(default=False)
 
@@ -538,22 +525,30 @@ class FileDownloader(BaseModel):
             elapsed = naturaldelta(time.perf_counter() - started, minimum_unit="milliseconds")
             entity_boundary_log(log, f"{method} ended in %s", elapsed, char="-")
 
-    @validator("local_path", "temp_path", pre=True, always=True)
+    @field_validator("local_path", "temp_path", mode="before")
+    @classmethod
     def _resolve_local_path(cls, value):
         return LocalPath(value).expanduser().resolve() if value else None
 
-    @validator("source_path", pre=True, always=True)
+    @field_validator("source_path", mode="before")
+    @classmethod
     def _validate_source_path(cls, value):
         return absolute_path(RemotePath(value)) if value else None
 
-    @root_validator(skip_on_failure=True)
-    def _validate_hwm(cls, values):
-        connection = values["connection"]
-        source_path = values.get("source_path")
-        hwm_type = values.get("hwm_type")
-        hwm = values.get("hwm")
+    @model_validator(mode="before")
+    @classmethod
+    def _hwm_type_to_hwm(cls, values):
+        connection = values.get("connection")
+        if not connection:
+            return values
 
-        if (hwm or hwm_type) and not source_path:
+        hwm_type = values.pop("hwm_type", None)
+        hwm = values.get("hwm")
+        if not hwm and not hwm_type:
+            return values
+
+        source_path = values.get("source_path")
+        if not source_path:
             msg = "If `hwm` is passed, `source_path` must be specified"
             raise ValueError(msg)
 
@@ -580,10 +575,31 @@ class FileDownloader(BaseModel):
                 directory=source_path,
             )
 
-        if hwm and not hwm.entity:
+        values["hwm"] = hwm
+        return values
+
+    # etl-entities v1 uses pydantic v1 models
+    # which are not compatible with pydantic v2.
+    # using a plain validator here
+    @field_validator("hwm", mode="plain")
+    @classmethod
+    def _validate_hwm(cls, hwm, info: ValidationInfo):
+        if not hwm:
+            return None
+
+        if not isinstance(hwm, FileHWM):
+            hwm = HWMTypeRegistry.parse(hwm)
+
+        if not isinstance(hwm, FileHWM):
+            msg = f"Expected FileHWM, got {hwm.__class__.__name__}"
+            raise ValueError(msg)  # noqa: TRY004
+
+        hwm = cast("FileHWM", hwm)
+        source_path = info.data.get("source_path")
+        if not hwm.entity:
             hwm = hwm.copy(update={"entity": source_path})
 
-        if hwm and hwm.entity != source_path:
+        if hwm.entity != source_path:
             error_message = textwrap.dedent(
                 f"""
                 Passed `hwm.directory` is different from `source_path`.
@@ -599,11 +615,10 @@ class FileDownloader(BaseModel):
             )
             raise ValueError(error_message)
 
-        values["hwm"] = hwm
-        values["hwm_type"] = None
-        return values
+        return hwm
 
-    @validator("filters", pre=True)
+    @field_validator("filters", mode="before")
+    @classmethod
     def _validate_filters(cls, filters):
         if filters is None:
             warnings.warn(
@@ -623,7 +638,8 @@ class FileDownloader(BaseModel):
 
         return filters
 
-    @validator("limits", pre=True)
+    @field_validator("limits", mode="before")
+    @classmethod
     def _validate_limits(cls, limits):
         if limits is None:
             warnings.warn(

--- a/onetl/file/filter/exclude_dir.py
+++ b/onetl/file/filter/exclude_dir.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 
-from pydantic import ConfigDict, field_validator
+from pydantic import field_validator
 
 from onetl.base import BaseFileFilter, PathProtocol, PurePathProtocol
 from onetl.impl import FrozenModel, RemotePath
@@ -33,8 +33,6 @@ class ExcludeDir(BaseFileFilter, FrozenModel):
 
     ```
     """
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     path: PurePathProtocol
 

--- a/onetl/file/filter/file_hwm.py
+++ b/onetl/file/filter/file_hwm.py
@@ -1,14 +1,10 @@
 # SPDX-FileCopyrightText: 2022-present MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 from etl_entities.hwm import FileHWM
-
-# using pydantic v1 for backward compatibility with etl-entities 3.x
-try:
-    from pydantic.v1 import BaseModel
-except (ImportError, AttributeError):
-    from pydantic import BaseModel  # type: ignore[no-redef, assignment]
+from pydantic import field_validator
 
 from onetl.base import BaseFileFilter, PathProtocol
+from onetl.impl import BaseModel
 
 
 class FileHWMFilter(BaseFileFilter, BaseModel):
@@ -26,12 +22,17 @@ class FileHWMFilter(BaseFileFilter, BaseModel):
         File HWM instance
     """
 
-    class Config:
-        frozen = True
-        extra = "forbid"
-        arbitrary_types_allowed = True
-
     hwm: FileHWM
+
+    # etl-entities v1 uses pydantic v1 models
+    # which are not compatible with pydantic v2.
+    # using a plain validator here
+    @field_validator("hwm", mode="plain")
+    @classmethod
+    def validate_hwm(cls, value):
+        if not isinstance(value, FileHWM):
+            return FileHWM.parse_obj(value)
+        return value
 
     def match(self, path: PathProtocol) -> bool:
         if path.is_dir():

--- a/onetl/hwm/store/yaml_hwm_store.py
+++ b/onetl/hwm/store/yaml_hwm_store.py
@@ -13,7 +13,6 @@ from etl_entities.hwm_store import (
     register_hwm_store_class,
 )
 from platformdirs import user_data_dir
-from pydantic.v1 import BaseModel
 
 from onetl.hooks import slot, support_hooks
 from onetl.impl import LocalPath
@@ -155,15 +154,15 @@ class YAMLHWMStore(BaseHWMStore):
     ITEMS_DELIMITER_PATTERN: ClassVar[re.Pattern] = re.compile("[#@|]+")
     PROHIBITED_SYMBOLS_PATTERN: ClassVar[re.Pattern] = re.compile(r"[=:/\\]+")
 
-    if issubclass(BaseHWMStore, BaseModel):
+    if hasattr(BaseHWMStore, "model_config"):
+        # pydantic v2
+        model_config: ClassVar = {"frozen": True, "extra": "forbid"}
+    else:
 
         class Config:
             # pydantic v1
             frozen = True
             extra = "forbid"
-    else:
-        # pydantic v2
-        model_config: ClassVar = {"frozen": True, "extra": "forbid"}
 
     def __init__(self, path: os.PathLike | str = DATA_PATH / "yml_hwm_store", encoding="utf-8"):
         path = LocalPath(path).expanduser().resolve()

--- a/onetl/impl/frozen_model.py
+++ b/onetl/impl/frozen_model.py
@@ -6,4 +6,4 @@ from onetl.impl.base_model import BaseModel
 
 
 class FrozenModel(BaseModel):
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, populate_by_name=True, arbitrary_types_allowed=True, extra="forbid")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

#531 left some `pydantic.v1` imports for compatibility with etl-entities 2.x. Actually, we can avoid that by using `model="plain"` validators.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
