### PR TITLE
[DOP-3146] Make Kafka(cluster=...) optional

### DIFF
--- a/mddocs/docs/changelog/next_release/539.breaking.1.md
+++ b/mddocs/docs/changelog/next_release/539.breaking.1.md
@@ -1,0 +1,1 @@
+Make `Kafka(cluster=...)` parameter optional.

--- a/mddocs/docs/changelog/next_release/539.breaking.2.md
+++ b/mddocs/docs/changelog/next_release/539.breaking.2.md
@@ -1,0 +1,1 @@
+Change `Kafka.instance_url` to return `kafka://some-cluster` instead of `some-cluster`.

--- a/onetl/connection/db_connection/kafka/connection.py
+++ b/onetl/connection/db_connection/kafka/connection.py
@@ -5,7 +5,7 @@ import logging
 from contextlib import closing
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from pydantic import ValidationInfo, field_validator, model_validator
+from pydantic import Field, ValidationInfo, field_validator
 
 from onetl._util.java import try_import_java_class
 from onetl._util.scala import get_default_scala_version
@@ -74,8 +74,19 @@ class Kafka(DBConnection):
     addresses : list[str]
         A list of broker addresses, for example `["192.168.1.10:9092", "192.168.1.11:9092"]`.
 
-    cluster : str
-        Cluster name. Used for HWM and lineage.
+        !!! warning
+
+            You should pass at least one of these arguments: `cluster`, `addresses`.
+
+    cluster : str, optional
+        Cluster name.
+
+        This can be used to get broker addresses dynamically, if `addresses` is not set.
+        Requires [Slots.get_cluster_addresses][onetl.connection.db_connection.kafka.slots.KafkaSlots.get_cluster_addresses] hook to be bound.
+
+        !!! warning
+
+            You should pass at least one of these arguments: `cluster`, `addresses`.
 
     auth : KafkaAuth, optional
         Kafka authentication mechanism. `None` means anonymous auth.
@@ -104,6 +115,7 @@ class Kafka(DBConnection):
             },
         )
         ```
+
         !!! warning
 
             Options that populated from connection
@@ -131,7 +143,6 @@ class Kafka(DBConnection):
         # Create connection
         kafka = Kafka(
             addresses=["mybroker:9092", "anotherbroker:9092"],
-            cluster="my-cluster",
             auth=Kafka.ScramAuth(
                 user="me",
                 password="abc",
@@ -150,7 +161,6 @@ class Kafka(DBConnection):
         # Create connection
         kafka = Kafka(
             addresses=["mybroker:9092", "anotherbroker:9092"],
-            cluster="my-cluster",
             auth=Kafka.KerberosAuth(
                 principal="me@example.com",
                 keytab="/path/to/keytab",
@@ -171,7 +181,6 @@ class Kafka(DBConnection):
         # Create connection
         kafka = Kafka(
             addresses=["mybroker:9092", "anotherbroker:9092"],
-            cluster="my-cluster",
             protocol=Kafka.SSLProtocol(
                 # read client certificate and private key from file
                 keystore_type="PEM",
@@ -201,7 +210,6 @@ class Kafka(DBConnection):
         # Create connection
         kafka = Kafka(
             addresses=["mybroker:9092", "anotherbroker:9092"],
-            cluster="my-cluster",
             protocol=Kafka.SSLProtocol(
                 # read server public certificate from file
                 truststore_type="PEM",
@@ -226,7 +234,6 @@ class Kafka(DBConnection):
         # Create connection
         kafka = Kafka(
             addresses=["mybroker:9092", "anotherbroker:9092"],
-            cluster="my-cluster",
             protocol=...,
             auth=...,
             extra={"max.request.size": 1024 * 1024},  # <--
@@ -247,8 +254,8 @@ class Kafka(DBConnection):
     PlaintextProtocol: ClassVar = KafkaPlaintextProtocol
     Slots: ClassVar = KafkaSlots
 
-    cluster: Cluster
-    addresses: list[str]
+    cluster: Cluster | None = None
+    addresses: list[str] = Field(default_factory=list, min_length=1, validate_default=True)
     auth: KafkaAuth | None = None
     protocol: KafkaProtocol = PlaintextProtocol()
     extra: KafkaExtra = KafkaExtra()
@@ -604,29 +611,15 @@ class Kafka(DBConnection):
         return min_offsets, max_offsets
 
     @property
-    def instance_url(self):
-        return "kafka://" + self.cluster
+    def instance_url(self) -> str:
+        if self.cluster:
+            return "kafka://" + self.cluster
+        return "kafka://" + ",".join(sorted(self.addresses))
 
     def __str__(self):
-        return f"{self.__class__.__name__}[{self.cluster}]"
-
-    @model_validator(mode="before")
-    @classmethod
-    def _get_addresses_by_cluster(cls, values):
-        addresses = values.get("addresses")
-        if addresses:
-            return values
-
-        cluster = values.get("cluster")
-        if cluster:
-            cluster_addresses = cls.Slots.get_cluster_addresses(cluster) or []
-            if cluster_addresses:
-                log.debug("|%s| Set cluster %r addresses: %r", cls.__name__, cluster, cluster_addresses)
-                values["addresses"] = cluster_addresses
-                return values
-
-        msg = "Passed empty parameter 'addresses'"
-        raise ValueError(msg)
+        if self.cluster:
+            return f"{self.__class__.__name__}[{self.cluster}]"
+        return f"{self.__class__.__name__}[" + ",".join(sorted(self.addresses)) + "]"
 
     @field_validator("cluster", mode="before")
     @classmethod
@@ -648,22 +641,23 @@ class Kafka(DBConnection):
     @classmethod
     def _validate_addresses(cls, value, info: ValidationInfo):
         cluster = info.data.get("cluster")
-        if not cluster:
-            return value
 
         log.debug("|%s| Normalizing addresses %r names...", cls.__name__, value)
 
-        validated_addresses = [cls.Slots.normalize_address(address, cluster) or address for address in value]
-        if validated_addresses != value:
-            log.debug("|%s| Got %r", cls.__name__, validated_addresses)
+        addresses = [cls.Slots.normalize_address(address, cluster) or address for address in value]
+        if addresses != value:
+            log.debug("|%s| Got %r", cls.__name__, addresses)
 
-        cluster_addresses = set(cls.Slots.get_cluster_addresses(cluster) or [])
-        unknown_addresses = set(validated_addresses) - cluster_addresses
-        if cluster_addresses and unknown_addresses:
-            msg = f"Cluster {cluster!r} does not contain addresses {unknown_addresses!r}"
+        known = []
+        if cluster:
+            known = cls.Slots.get_cluster_addresses(cluster) or []
+
+        unknown = (set(addresses) - set(known)) if known else set()
+        if unknown:
+            msg = f"Cluster {cluster!r} does not contain addresses {sorted(unknown)!r}"
             raise ValueError(msg)
 
-        return validated_addresses
+        return addresses or known
 
     @field_validator("spark", mode="before")
     @classmethod

--- a/onetl/connection/db_connection/kafka/slots.py
+++ b/onetl/connection/db_connection/kafka/slots.py
@@ -78,9 +78,9 @@ class KafkaSlots:
 
     @slot
     @staticmethod
-    def normalize_address(address: str, cluster: str) -> str | None:
+    def normalize_address(address: str, cluster: str | None) -> str | None:
         """
-        Normalize the given broker address for a specific Kafka cluster.
+        Normalize the given broker address.
 
         This can be used to format the broker address according to specific rules, such as adding default ports.
 
@@ -90,8 +90,10 @@ class KafkaSlots:
         ----------
         address : str
             The original broker address.
-        cluster : str
+        cluster : str, optional
             The Kafka cluster name for which the address should be normalized.
+
+            !!! info "Since 0.17.0 this parameter is optional"
 
         Returns
         -------

--- a/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_kafka_reader_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_reader_integration/test_kafka_reader_integration.py
@@ -78,7 +78,6 @@ def test_kafka_reader(spark, processing, kafka_dataframe_schema, kafka_topic):
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     reader = DBReader(
@@ -100,7 +99,6 @@ def test_kafka_reader_columns_and_types_without_headers(spark, processing, kafka
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     reader = DBReader(
@@ -120,7 +118,6 @@ def test_kafka_reader_columns_and_types_with_headers(spark, processing, kafka_sc
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     # Check that the DataFrame also has a "headers" column when includeHeaders=True
@@ -142,7 +139,6 @@ def test_kafka_reader_topic_does_not_exist(spark, processing):
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     reader = DBReader(
@@ -162,7 +158,6 @@ def test_kafka_reader_with_group_id(group_id_option, spark, processing, kafka_da
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
         extra={group_id_option: "test"},
     )
 
@@ -189,7 +184,6 @@ def test_kafka_reader_snapshot_nothing_to_read(spark, processing, kafka_datafram
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     reader = DBReader(

--- a/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_kafka_writer_integration.py
+++ b/tests/tests_integration/tests_core_integration/tests_db_writer_integration/test_kafka_writer_integration.py
@@ -69,7 +69,6 @@ def test_kafka_writer(spark, kafka_processing, kafka_spark_df):
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     writer = DBWriter(
@@ -98,7 +97,6 @@ def test_kafka_writer_no_value_column_error(spark, kafka_processing, kafka_spark
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     writer = DBWriter(
@@ -136,7 +134,6 @@ def test_kafka_writer_invalid_column_error(
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     writer = DBWriter(
@@ -159,7 +156,6 @@ def test_kafka_writer_key_column(spark, kafka_processing, kafka_spark_df):
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     writer = DBWriter(
@@ -185,7 +181,6 @@ def test_kafka_writer_topic_column(spark, kafka_processing, caplog, kafka_spark_
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     writer = DBWriter(
@@ -210,7 +205,6 @@ def test_kafka_writer_partition_column(spark, kafka_processing, kafka_spark_df):
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     writer = DBWriter(
@@ -232,7 +226,6 @@ def test_kafka_writer_headers(spark, kafka_processing, kafka_spark_df):
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     writer = DBWriter(
@@ -258,7 +251,6 @@ def test_kafka_writer_headers_without_include_headers_fail(spark, kafka_processi
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     writer = DBWriter(
@@ -280,7 +272,6 @@ def test_kafka_writer_mode(spark, kafka_processing, kafka_spark_df):
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     writer = DBWriter(
@@ -307,7 +298,6 @@ def test_kafka_writer_mode_error(spark, kafka_processing, kafka_spark_df):
     kafka = Kafka(
         spark=spark,
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
     )
 
     writer = DBWriter(

--- a/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_kafka_integration.py
@@ -14,7 +14,6 @@ def test_kafka_check_plaintext_anonymous(spark, caplog):
 
     kafka = Kafka(
         addresses=[f"{kafka_processing.host}:{kafka_processing.port}"],
-        cluster="cluster",
         spark=spark,
     )
     with caplog.at_level(logging.INFO):
@@ -23,7 +22,7 @@ def test_kafka_check_plaintext_anonymous(spark, caplog):
     assert "|Kafka|" in caplog.text
     assert "addresses = [" in caplog.text
     assert f"'{kafka_processing.host}:{kafka_processing.port}'" in caplog.text
-    assert "cluster = 'cluster'" in caplog.text
+    assert "cluster = None" in caplog.text
     assert "protocol = KafkaPlaintextProtocol()" in caplog.text
     assert "auth = None" in caplog.text
     assert "extra = {}" in caplog.text
@@ -38,7 +37,6 @@ def test_kafka_check_plaintext_basic_auth(spark, caplog):
 
     kafka = Kafka(
         addresses=[f"{kafka_processing.host}:{kafka_processing.sasl_port}"],
-        cluster="cluster",
         spark=spark,
         auth=Kafka.BasicAuth(
             username=kafka_processing.user,
@@ -51,7 +49,7 @@ def test_kafka_check_plaintext_basic_auth(spark, caplog):
     assert "|Kafka|" in caplog.text
     assert "addresses = [" in caplog.text
     assert f"'{kafka_processing.host}:{kafka_processing.sasl_port}'" in caplog.text
-    assert "cluster = 'cluster'" in caplog.text
+    assert "cluster = None" in caplog.text
     assert "protocol = KafkaPlaintextProtocol()" in caplog.text
     assert f"auth = KafkaBasicAuth(user='{kafka_processing.user}', password=SecretStr('**********'))" in caplog.text
     assert "extra = {}" in caplog.text
@@ -67,7 +65,6 @@ def test_kafka_check_plaintext_scram_auth(digest, spark, caplog):
 
     kafka = Kafka(
         addresses=[f"{kafka_processing.host}:{kafka_processing.sasl_port}"],
-        cluster="cluster",
         spark=spark,
         auth=Kafka.ScramAuth(
             username=kafka_processing.user,
@@ -81,7 +78,7 @@ def test_kafka_check_plaintext_scram_auth(digest, spark, caplog):
     assert "|Kafka|" in caplog.text
     assert "addresses = [" in caplog.text
     assert f"'{kafka_processing.host}:{kafka_processing.sasl_port}'" in caplog.text
-    assert "cluster = 'cluster'" in caplog.text
+    assert "cluster = None" in caplog.text
     assert "protocol = KafkaPlaintextProtocol()" in caplog.text
     assert (
         f"auth = KafkaScramAuth(user='{kafka_processing.user}', password=SecretStr('**********'), digest='{digest}')"
@@ -95,7 +92,6 @@ def test_kafka_check_plaintext_scram_auth(digest, spark, caplog):
 def test_kafka_check_error(spark):
     kafka = Kafka(
         addresses=["fake:9092"],
-        cluster="cluster",
         spark=spark,
     )
     with pytest.raises(RuntimeError, match="Connection is unavailable"):

--- a/tests/tests_integration/tests_db_connection_integration/test_kafka_oauth_integration.py
+++ b/tests/tests_integration/tests_db_connection_integration/test_kafka_oauth_integration.py
@@ -12,7 +12,6 @@ def test_kafka_oauth2_client_credentials_read_write(spark, processing):
     topic = f"oauth_{secrets.token_hex(5)}"
     kafka = Kafka(
         addresses=[f"{processing.oauth_host}:{processing.oauth_port}"],
-        cluster="cluster",
         spark=spark,
         auth=Kafka.OAuth2ClientCredentials(
             client_id=processing.oauth_client_id,
@@ -34,7 +33,6 @@ def test_kafka_oauth2_client_credentials_read_write(spark, processing):
 def test_kafka_oauth2_client_credentials_invalid_secret(spark, processing):
     kafka = Kafka(
         addresses=[f"{processing.oauth_host}:{processing.oauth_port}"],
-        cluster="cluster",
         spark=spark,
         auth=Kafka.OAuth2ClientCredentials(
             client_id=processing.oauth_client_id,

--- a/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_kafka.py
+++ b/tests/tests_integration/tests_strategy_integration/tests_incremental_strategy_integration/test_strategy_increment_kafka.py
@@ -33,7 +33,6 @@ def test_kafka_strategy_incremental(
 
     kafka = Kafka(
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
         spark=spark,
     )
 
@@ -132,7 +131,6 @@ def test_kafka_strategy_incremental_nothing_to_read(
 
     kafka = Kafka(
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
         spark=spark,
     )
 
@@ -252,7 +250,6 @@ def test_kafka_strategy_incremental_with_new_partition(
 
     kafka = Kafka(
         addresses=[f"{processing.host}:{processing.port}"],
-        cluster="cluster",
         spark=spark,
     )
 

--- a/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
@@ -139,115 +139,46 @@ def test_kafka_read_options_allowed(option, value):
     assert getattr(options, option) == value
 
 
+def test_kafka_empty_addresses(spark_mock):
+    with pytest.raises(
+        ValueError,
+        match=re.escape("List should have at least 1 item after validation"),
+    ):
+        Kafka(spark=spark_mock)
+
+
+def test_kafka_with_addresses(spark_mock):
+    conn = Kafka(
+        spark=spark_mock,
+        addresses=["192.168.1.2", "192.168.1.1"],
+    )
+    assert not conn.auth
+    assert conn.addresses == ["192.168.1.2", "192.168.1.1"]
+    assert conn.cluster is None
+
+    assert conn.instance_url == "kafka://192.168.1.1,192.168.1.2"
+    assert str(conn) == "Kafka[192.168.1.1,192.168.1.2]"
+
+
+def test_kafka_with_cluster_and_addresses(spark_mock):
+    conn = Kafka(
+        spark=spark_mock,
+        cluster="some_cluster",
+        addresses=["192.168.1.2", "192.168.1.1"],
+    )
+
+    assert conn.addresses == ["192.168.1.2", "192.168.1.1"]
+    assert conn.cluster == "some_cluster"
+
+    assert conn.instance_url == "kafka://some_cluster"
+    assert str(conn) == "Kafka[some_cluster]"
+
+
 @pytest.mark.parametrize("value", [True, False])
 @pytest.mark.parametrize("options_class", [Kafka.ReadOptions, Kafka.WriteOptions])
 def test_kafka_options_include_headers(options_class, value):
     options = options_class(includeHeaders=value)
     assert options.include_headers == value
-
-
-def test_kafka_basic_auth_get_jaas_conf(spark_mock):
-    conn = Kafka(
-        spark=spark_mock,
-        cluster="some_cluster",
-        addresses=["192.168.1.1"],
-        auth=Kafka.BasicAuth(
-            user="user",
-            password="passwd",
-        ),
-    )
-
-    assert conn.auth.user == "user"
-    assert conn.cluster == "some_cluster"
-    assert conn.auth.password != "passwd"
-    assert conn.auth.password.get_secret_value() == "passwd"
-    assert conn.addresses == ["192.168.1.1"]
-
-    assert conn.instance_url == "kafka://some_cluster"
-    assert str(conn) == "Kafka[some_cluster]"
-
-
-def test_kafka_anon_auth(spark_mock):
-    conn = Kafka(
-        spark=spark_mock,
-        cluster="some_cluster",
-        addresses=["192.168.1.1"],
-    )
-    assert not conn.auth
-    assert conn.cluster == "some_cluster"
-    assert conn.addresses == ["192.168.1.1"]
-
-    assert conn.instance_url == "kafka://some_cluster"
-    assert str(conn) == "Kafka[some_cluster]"
-
-
-@pytest.mark.parametrize("digest", ["SHA-256", "SHA-512"])
-def test_kafka_scram_auth(spark_mock, digest):
-    conn = Kafka(
-        spark=spark_mock,
-        cluster="some_cluster",
-        addresses=["192.168.1.1"],
-        auth=Kafka.ScramAuth(
-            user="user",
-            password="passwd",
-            digest=digest,
-        ),
-    )
-
-    assert conn.auth.user == "user"
-    assert conn.cluster == "some_cluster"
-    assert conn.auth.password != "passwd"
-    assert conn.auth.password.get_secret_value() == "passwd"
-    assert conn.auth.digest == digest
-    assert conn.addresses == ["192.168.1.1"]
-
-    assert conn.instance_url == "kafka://some_cluster"
-    assert str(conn) == "Kafka[some_cluster]"
-
-
-def test_kafka_auth_keytab(spark_mock, create_keytab):
-    conn = Kafka(
-        spark=spark_mock,
-        cluster="some_cluster",
-        addresses=["192.168.1.1"],
-        auth=Kafka.KerberosAuth(
-            principal="user",
-            keytab=create_keytab,
-        ),
-    )
-
-    assert conn.auth.principal == "user"
-    assert conn.cluster == "some_cluster"
-    assert conn.addresses == ["192.168.1.1"]
-
-    assert conn.instance_url == "kafka://some_cluster"
-    assert str(conn) == "Kafka[some_cluster]"
-
-
-def test_kafka_empty_addresses(spark_mock):
-    with pytest.raises(
-        ValueError,
-        match=re.escape("Passed empty parameter 'addresses'"),
-    ):
-        Kafka(
-            spark=spark_mock,
-            password="passwd",
-            user="user",
-            cluster="some_cluster",
-            addresses=[],
-        )
-
-
-def test_kafka_empty_cluster(spark_mock):
-    with pytest.raises(ValueError, match=" Field required"):
-        Kafka(
-            spark=spark_mock,
-            addresses=["192.168.1.1"],
-            auth=Kafka.BasicAuth(
-                password="passwd",
-                user="user",
-            ),
-        )
 
 
 @pytest.mark.parametrize(
@@ -502,7 +433,7 @@ def test_kafka_scram_auth_unknown_options(option, caplog):
 
 
 @pytest.mark.parametrize("digest", ["SHA-256", "SHA-512"])
-def test_kafka_scram_auth_get_jaas_conf(spark_mock, digest):
+def test_kafka_scram_auth(spark_mock, digest):
     kafka = Kafka(
         spark=spark_mock,
         addresses=["some_address"],
@@ -751,6 +682,21 @@ def test_kafka_normalize_cluster_name_hook(request, spark_mock):
     assert Kafka(cluster="KAFKA-CLUSTER", spark=spark_mock, addresses=["192.168.1.1"]).cluster == "kafka-cluster"
 
 
+def test_kafka_no_get_known_clusters_hook(spark_mock):
+    with pytest.raises(
+        ValueError,
+        match=re.escape("List should have at least 1 item after validation"),
+    ):
+        Kafka(
+            spark=spark_mock,
+            cluster="some_cluster",  # without hook there is no source for addresses
+            auth=Kafka.BasicAuth(
+                password="passwd",
+                user="user",
+            ),
+        )
+
+
 def test_kafka_get_known_clusters_hook(request, spark_mock):
     @Kafka.Slots.get_known_clusters.bind
     @hook
@@ -769,7 +715,7 @@ def test_kafka_get_known_clusters_hook(request, spark_mock):
 def test_kafka_normalize_address_hook(request, spark_mock):
     @Kafka.Slots.normalize_address.bind
     @hook
-    def normalize_address(address: str, cluster: str):
+    def normalize_address(address: str, cluster: str | None):
         if cluster == "kafka-cluster":
             return f"{address}:9093"
         if cluster == "local":
@@ -797,7 +743,8 @@ def test_kafka_get_cluster_addresses_hook(request, spark_mock):
         "192.168.1.2",
     ]
 
-    with pytest.raises(ValueError, match=r"Cluster 'kafka-cluster' does not contain addresses \{'192.168.1.3'\}"):
+    msg = "Cluster 'kafka-cluster' does not contain addresses ['192.168.1.3']"
+    with pytest.raises(ValueError, match=re.escape(msg)):
         Kafka(cluster="kafka-cluster", spark=spark_mock, addresses=["192.168.1.1", "192.168.1.3"])
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

`Kafka(cluster=...)` parameter was initially added for 2 future cases:
* There will be extra validation library for Kafka clusters & addresses
* Kafka.instance_url will be used for Lineage

This made parameter mandatory, although it is currently just a noise. Let's make it optional.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
