### PR TITLE
[DOP-6708] Make SparkHDFS(cluster=...) parameter optional

### DIFF
--- a/mddocs/docs/changelog/next_release/540.breaking.1.md
+++ b/mddocs/docs/changelog/next_release/540.breaking.1.md
@@ -1,0 +1,1 @@
+Make `SparkHDFS(cluster=...)` parameter optional.

--- a/mddocs/docs/changelog/next_release/540.breaking.2.md
+++ b/mddocs/docs/changelog/next_release/540.breaking.2.md
@@ -1,0 +1,1 @@
+Change `Hive.instance_url` to return `hive://some-cluster` instead of `some-cluster`.

--- a/mddocs/docs/changelog/next_release/540.breaking.3.md
+++ b/mddocs/docs/changelog/next_release/540.breaking.3.md
@@ -1,0 +1,1 @@
+Change `HDFS.instance_url` and `SparkHDFS.instance_url` to return `hdfs://some-cluster` instead of `some-cluster`.

--- a/onetl/connection/db_connection/hive/connection.py
+++ b/onetl/connection/db_connection/hive/connection.py
@@ -155,7 +155,7 @@ class Hive(DBConnection):
 
     @property
     def instance_url(self) -> str:
-        return self.cluster
+        return "hive://" + self.cluster
 
     def __str__(self):
         return f"{self.__class__.__name__}[{self.cluster}]"

--- a/onetl/connection/file_connection/hdfs/connection.py
+++ b/onetl/connection/file_connection/hdfs/connection.py
@@ -312,7 +312,7 @@ class HDFS(FileConnection, RenameDirMixin):
     @property
     def instance_url(self) -> str:
         if self.cluster:
-            return self.cluster
+            return "hdfs://" + self.cluster
         return f"hdfs://{self.host}:{self.webhdfs_port}"
 
     def __str__(self):
@@ -476,32 +476,26 @@ class HDFS(FileConnection, RenameDirMixin):
         raise RuntimeError(msg)
 
     def _get_host(self) -> str:
-        host = cast("str", self.host)
-
-        if not host and self.cluster:
+        if not self.host:
             return self._get_active_namenode()
 
         # host is passed explicitly or cluster not set
         class_name = self.__class__.__name__
         if self.cluster:
-            log.info("|%s| Detecting if namenode %r of cluster %r is active...", class_name, host, self.cluster)
+            log.info("|%s| Detecting if namenode %r of cluster %r is active...", class_name, self.host, self.cluster)
         else:
-            log.info("|%s| Detecting if namenode %r is active...", class_name, host)
+            log.info("|%s| Detecting if namenode %r is active...", class_name, self.host)
 
-        is_active = self.Slots.is_namenode_active(cast("str", host), self.cluster)
+        is_active = self.Slots.is_namenode_active(self.host, self.cluster)
         if is_active:
-            log.info("|%s|   Namenode %r is active!", class_name, host)
-            return host
+            log.info("|%s|   Namenode %r is active!", class_name, self.host)
+            return self.host
 
         if is_active is None:
             log.debug("|%s|   No hooks, skip validation", class_name)
-            return host
+            return self.host
 
-        if self.cluster:
-            msg = f"Host {host!r} is not an active namenode of cluster {self.cluster!r}"
-            raise RuntimeError(msg)
-
-        msg = f"Host {host!r} is not an active namenode"
+        msg = f"Host {self.host!r} is not an active namenode of cluster {self.cluster!r}"
         raise RuntimeError(msg)
 
     def _get_conn_str(self) -> str:

--- a/onetl/connection/file_df_connection/spark_hdfs/connection.py
+++ b/onetl/connection/file_df_connection/spark_hdfs/connection.py
@@ -4,7 +4,7 @@ import getpass
 import logging
 import os
 from contextlib import suppress
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from pydantic import Field, PrivateAttr, ValidationInfo, field_validator, model_validator
 
@@ -145,7 +145,7 @@ class SparkHDFS(SparkFileDFConnection):
 
     Slots: ClassVar = SparkHDFSSlots
 
-    cluster: Cluster
+    cluster: Cluster | None = None
     host: Host | None = None
     ipc_port: int = Field(alias=avoid_alias("port"), default=DEFAULT_IPC_PORT, validate_default=True)  # type: ignore[literal-required]
 
@@ -156,11 +156,15 @@ class SparkHDFS(SparkFileDFConnection):
         return RemotePath(os.fspath(path))
 
     @property
-    def instance_url(self):
-        return self.cluster
+    def instance_url(self) -> str:
+        if self.cluster:
+            return "hdfs://" + self.cluster
+        return f"hdfs://{self.host}"
 
     def __str__(self):
-        return f"HDFS[{self.cluster}]"
+        if self.cluster:
+            return f"HDFS[{self.cluster}]"
+        return f"HDFS[{self.host}]"
 
     def __enter__(self):
         return self
@@ -252,6 +256,18 @@ class SparkHDFS(SparkFileDFConnection):
         log.info("|%s|   Got %r", cls.__name__, current_cluster)
         return cls(cluster=current_cluster, spark=spark)  # type: ignore[arg-type]
 
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_cluster_or_hostname_set(cls, values):
+        host = values.get("host")
+        cluster = values.get("cluster")
+
+        if not cluster and not host:
+            msg = "You should pass either host or cluster name"
+            raise ValueError(msg)
+
+        return values
+
     @field_validator("cluster", mode="before")
     @classmethod
     def _validate_cluster_name(cls, cluster):
@@ -272,8 +288,6 @@ class SparkHDFS(SparkFileDFConnection):
     @classmethod
     def _validate_host_name(cls, host, info: ValidationInfo):
         cluster = info.data.get("cluster")
-        if not cluster:
-            return host
 
         log.debug("|%s| Normalizing namenode %r host...", cls.__name__, host)
         namenode = cls.Slots.normalize_namenode_host(host, cluster) or host
@@ -308,22 +322,23 @@ class SparkHDFS(SparkFileDFConnection):
 
     def _get_active_namenode(self) -> str:
         class_name = self.__class__.__name__
-        log.info("|%s| Detecting active namenode of cluster %r ...", class_name, self.cluster)
+        cluster = cast("str", self.cluster)
+        log.info("|%s| Detecting active namenode of cluster %r ...", class_name, cluster)
 
-        namenodes = self.Slots.get_cluster_namenodes(self.cluster)
+        namenodes = self.Slots.get_cluster_namenodes(cluster)
         if not namenodes:
-            msg = f"Cannot get list of namenodes for a cluster {self.cluster!r}"
+            msg = f"Cannot get list of namenodes for a cluster {cluster!r}"
             raise RuntimeError(msg)
 
         nodes_len = len(namenodes)
         for i, namenode in enumerate(namenodes, start=1):
             log.debug("|%s|   Trying namenode %r (%d of %d) ...", class_name, namenode, i, nodes_len)
-            if self.Slots.is_namenode_active(namenode, self.cluster):
+            if self.Slots.is_namenode_active(namenode, cluster):
                 log.info("|%s|     Node %r is active!", class_name, namenode)
                 return namenode
             log.debug("|%s|     Node %r is not active, skipping", class_name, namenode)
 
-        msg = f"Cannot detect active namenode for cluster {self.cluster!r}"
+        msg = f"Cannot detect active namenode for cluster {cluster!r}"
         raise RuntimeError(msg)
 
     def _get_host(self) -> str:

--- a/onetl/connection/file_df_connection/spark_hdfs/slots.py
+++ b/onetl/connection/file_df_connection/spark_hdfs/slots.py
@@ -49,7 +49,7 @@ class SparkHDFSSlots:
 
     @slot
     @staticmethod
-    def normalize_namenode_host(host: str, cluster: str) -> str | None:
+    def normalize_namenode_host(host: str, cluster: str | None) -> str | None:
         """
         Normalize namenode host passed into SparkHDFS constructor.
 
@@ -62,8 +62,10 @@ class SparkHDFSSlots:
         host : str
             Namenode host (raw)
 
-        cluster : str
+        cluster : str, optional
             Cluster name (normalized)
+
+            !!! info "Since 0.17.0 this parameter is optional"
 
         Returns
         -------
@@ -204,7 +206,7 @@ class SparkHDFSSlots:
     @staticmethod
     def get_ipc_port(cluster: str) -> int | None:
         """
-        Get IPC port number for a specific cluster.
+        Get IPC port number.
 
         Used by constructor to automatically set port number if omitted.
 
@@ -241,7 +243,7 @@ class SparkHDFSSlots:
 
     @slot
     @staticmethod
-    def is_namenode_active(host: str, cluster: str) -> bool | None:
+    def is_namenode_active(host: str, cluster: str | None) -> bool | None:
         """
         Check whether a namenode of a specified cluster is active (=not standby) or not.
 
@@ -262,8 +264,10 @@ class SparkHDFSSlots:
         host : str
             Namenode host (normalized)
 
-        cluster : str
+        cluster : str, optional
             Cluster name (normalized)
+
+            !!! info "Since 0.17.0 this parameter is optional"
 
         Returns
         -------

--- a/tests/tests_unit/tests_db_connection_unit/test_hive_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_hive_unit.py
@@ -23,7 +23,7 @@ def test_hive_missing_args(spark_mock):
 
 def test_hive_instance_url(spark_mock):
     hive = Hive(cluster="some-cluster", spark=spark_mock)
-    assert hive.instance_url == "some-cluster"
+    assert hive.instance_url == "hive://some-cluster"
 
 
 def test_hive_spark_stopped(spark_stopped):

--- a/tests/tests_unit/tests_file_connection_unit/test_hdfs_unit.py
+++ b/tests/tests_unit/tests_file_connection_unit/test_hdfs_unit.py
@@ -36,7 +36,7 @@ def test_hdfs_connection_with_cluster():
     assert not conn.user
     assert not conn.password
     assert not conn.keytab
-    assert conn.instance_url == "rnd-dwh"
+    assert conn.instance_url == "hdfs://rnd-dwh"
     assert str(conn) == "HDFS[rnd-dwh]"
 
 
@@ -46,7 +46,7 @@ def test_hdfs_connection_with_cluster_and_host():
     conn = HDFS(cluster="rnd-dwh", host="some-host.domain.com")
     assert conn.cluster == "rnd-dwh"
     assert conn.host == "some-host.domain.com"
-    assert conn.instance_url == "rnd-dwh"
+    assert conn.instance_url == "hdfs://rnd-dwh"
     assert str(conn) == "HDFS[rnd-dwh]"
 
 

--- a/tests/tests_unit/tests_file_df_connection_unit/test_spark_hdfs_unit.py
+++ b/tests/tests_unit/tests_file_df_connection_unit/test_spark_hdfs_unit.py
@@ -4,7 +4,6 @@ import re
 
 import pytest
 
-from onetl.base import BaseFileDFConnection
 from onetl.connection import SparkHDFS
 from onetl.hooks import hook
 
@@ -13,29 +12,26 @@ pytestmark = [pytest.mark.hdfs, pytest.mark.file_df_connection, pytest.mark.conn
 
 def test_spark_hdfs_with_cluster(spark_mock):
     conn = SparkHDFS(cluster="rnd-dwh", spark=spark_mock)
-    assert isinstance(conn, BaseFileDFConnection)
     assert conn.cluster == "rnd-dwh"
     assert conn.host is None
     assert conn.ipc_port == 8020
-    assert conn.instance_url == "rnd-dwh"
+    assert conn.instance_url == "hdfs://rnd-dwh"
     assert str(conn) == "HDFS[rnd-dwh]"
 
 
 def test_spark_hdfs_with_cluster_and_host(spark_mock):
     conn = SparkHDFS(cluster="rnd-dwh", host="some-host.domain.com", spark=spark_mock)
-    assert isinstance(conn, BaseFileDFConnection)
     assert conn.cluster == "rnd-dwh"
     assert conn.host == "some-host.domain.com"
-    assert conn.instance_url == "rnd-dwh"
+    assert conn.instance_url == "hdfs://rnd-dwh"
     assert str(conn) == "HDFS[rnd-dwh]"
 
 
 def test_spark_hdfs_with_port(spark_mock):
     conn1 = SparkHDFS(cluster="rnd-dwh", ipc_port=9020, spark=spark_mock)
-    assert isinstance(conn1, BaseFileDFConnection)
     assert conn1.cluster == "rnd-dwh"
     assert conn1.ipc_port == 9020
-    assert conn1.instance_url == "rnd-dwh"
+    assert conn1.instance_url == "hdfs://rnd-dwh"
     assert str(conn1) == "HDFS[rnd-dwh]"
 
     conn2 = SparkHDFS(cluster="rnd-dwh", port=9020, spark=spark_mock)
@@ -43,12 +39,23 @@ def test_spark_hdfs_with_port(spark_mock):
     assert conn1 == conn2
 
 
-def test_spark_hdfs_without_cluster(spark_mock):
-    with pytest.raises(ValueError):
+def test_spark_hdfs_without_cluster_and_host(spark_mock):
+    with pytest.raises(ValueError, match="You should pass either host or cluster name"):
         SparkHDFS(spark=spark_mock)
 
-    with pytest.raises(ValueError):
-        SparkHDFS(host="some", spark=spark_mock)
+
+def test_spark_hdfs_without_cluster(spark_mock):
+    conn1 = SparkHDFS(host="some", spark=spark_mock)
+    assert conn1.host == "some"
+    assert conn1.cluster is None
+    assert conn1.ipc_port == 8020
+    assert conn1.instance_url == "hdfs://some"
+
+    conn2 = SparkHDFS(host="some", port=9020, spark=spark_mock)
+    assert conn2.host == "some"
+    assert conn2.cluster is None
+    assert conn2.ipc_port == 9020
+    assert conn2.instance_url == "hdfs://some"
 
 
 def test_spark_hdfs_spark_stopped(spark_stopped):
@@ -108,7 +115,7 @@ def test_spark_hdfs_get_cluster_namenodes_hook(request, spark_mock):
 def test_spark_hdfs_normalize_namenode_host_hook(request, spark_mock):
     @SparkHDFS.Slots.normalize_namenode_host.bind
     @hook
-    def normalize_namenode_host(host: str, cluster: str) -> str:
+    def normalize_namenode_host(host: str, cluster: str | None) -> str:
         host = host.lower()
         if cluster == "rnd-dwh" and not host.endswith(".domain.com"):
             host += ".domain.com"
@@ -117,7 +124,7 @@ def test_spark_hdfs_normalize_namenode_host_hook(request, spark_mock):
     request.addfinalizer(normalize_namenode_host.disable)
 
     assert SparkHDFS(host="some-node", cluster="rnd-dwh", spark=spark_mock).host == "some-node.domain.com"
-    assert SparkHDFS(host="some-node", cluster="rnd-prod", spark=spark_mock).host == "some-node"
+    assert SparkHDFS(host="some-node", spark=spark_mock).host == "some-node"
 
 
 def test_spark_hdfs_get_ipc_port_hook(request, spark_mock):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

`HDFS(cluster=...)` parameter is optional but `SparkHDFS(cluster=...)` was not.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
