### PR TITLE
[DOP-8019] Improve Kafka.KerberosAuth

### DIFF
--- a/mddocs/docs/changelog/next_release/541.improvement.md
+++ b/mddocs/docs/changelog/next_release/541.improvement.md
@@ -1,0 +1,1 @@
+Improve `Kafka.KerberosAuth` defaults.

--- a/onetl/connection/db_connection/kafka/kafka_kerberos_auth.py
+++ b/onetl/connection/db_connection/kafka/kafka_kerberos_auth.py
@@ -5,7 +5,7 @@ import os
 import shutil
 from typing import TYPE_CHECKING, cast
 
-from pydantic import ConfigDict, Field, PrivateAttr, field_validator, model_validator
+from pydantic import ConfigDict, Field, PrivateAttr, field_validator
 
 from onetl._util.file import get_file_hash, readable_local_file
 from onetl._util.spark import stringify
@@ -20,16 +20,12 @@ log = logging.getLogger(__name__)
 
 KNOWN_OPTIONS = frozenset(
     (
-        "clearPass",
         "debug",
-        "doNotPrompt",
-        "isInitiator",
         "refreshKrb5Config",
         "renewTGT",
-        "storePass",
+        "storeKey",
         "ticketCache",
-        "tryFirstPass",
-        "useFirstPass",
+        "useTicketCache",
         "sasl.kerberos.*",
     ),
 )
@@ -86,11 +82,7 @@ class KafkaKerberosAuth(KafkaAuth, GenericOptions):
     ```python
     from onetl.connection import Kafka
 
-    auth = Kafka.KerberosAuth(
-        principal="user",
-        use_keytab=False,
-        use_ticket_cache=True,
-    )
+    auth = Kafka.KerberosAuth(principal="user")
     ```
     Pass custom options for JAAS config and Kafka SASL:
 
@@ -115,10 +107,6 @@ class KafkaKerberosAuth(KafkaAuth, GenericOptions):
     keytab: LocalPath | None = Field(default=None, alias="keyTab")
     deploy_keytab: bool = True
     service_name: str = Field(default="kafka", alias="serviceName")
-    renew_ticket: bool = Field(default=True, alias="renewTicket")
-    store_key: bool = Field(default=True, alias="storeKey")
-    use_keytab: bool = Field(default=True, alias="useKeyTab")
-    use_ticket_cache: bool = Field(default=False, alias="useTicketCache")
 
     _keytab_path: LocalPath | None = PrivateAttr(default=None)
     model_config = ConfigDict(
@@ -134,8 +122,14 @@ class KafkaKerberosAuth(KafkaAuth, GenericOptions):
             exclude_none=True,
             exclude={"deploy_keytab"},
         )
+        options.setdefault("doNotPrompt", True)  # default False
+        options.setdefault("useTicketCache", True)  # default False
+
         if self.keytab:
+            options["useKeyTab"] = True
             options["keyTab"] = self._prepare_keytab(kafka)
+        else:
+            options["useKeyTab"] = False
 
         jaas_conf = stringify({key: value for key, value in options.items() if not key.startswith("sasl.")}, quote=True)
         jaas_conf_items = [f"{key}={value}" for key, value in jaas_conf.items()]
@@ -169,13 +163,6 @@ class KafkaKerberosAuth(KafkaAuth, GenericOptions):
     @classmethod
     def _validate_keytab(cls, value):
         return readable_local_file(LocalPath(value).expanduser().resolve())
-
-    @model_validator(mode="after")
-    def _check_use_keytab(self):
-        if self.use_keytab and not self.keytab:
-            msg = "keytab is required if useKeytab is True"
-            raise ValueError(msg)
-        return self
 
     def _prepare_keytab(self, kafka: "Kafka") -> str:
         keytab = cast("LocalPath", self.keytab)

--- a/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
+++ b/tests/tests_unit/tests_db_connection_unit/test_kafka_unit.py
@@ -324,14 +324,6 @@ def test_kafka_kerberos_auth_wrong_keytab_type_error(tmp_path_factory):
         )
 
 
-def test_kafka_kerberos_auth_use_keytab_without_keytab():
-    with pytest.raises(
-        ValueError,
-        match="keytab is required if useKeytab is True",
-    ):
-        Kafka.KerberosAuth(principal="user")
-
-
 @pytest.mark.parametrize("option", ["sasl.kerberos.service.name", "sasl.jaas.config", "sasl.mechanism"])
 def test_kafka_kerberos_auth_prohibited_options(option, create_keytab):
     msg = rf"Options \['{option}'\] are not allowed to use in a KafkaKerberosAuth"
@@ -569,10 +561,9 @@ def test_kafka_kerberos_auth_deploy_keytab_false(spark_mock, create_keytab, keyt
                 'principal="user" '
                 f'keyTab="{create_keytab}" '
                 'serviceName="kafka" '
-                "renewTicket=true "
-                "storeKey=true "
-                "useKeyTab=true "
-                "useTicketCache=false;"
+                "doNotPrompt=true "
+                "useTicketCache=true "
+                "useKeyTab=true;"
             ),
             "sasl.kerberos.service.name": "kafka",
         }
@@ -604,10 +595,9 @@ def test_kafka_kerberos_auth_deploy_keytab_true(spark_mock, create_keytab, keyta
                 'principal="user" '
                 f'keyTab="{keytab_path.name}" '
                 'serviceName="kafka" '
-                "renewTicket=true "
-                "storeKey=true "
-                "useKeyTab=true "
-                "useTicketCache=false;"
+                "doNotPrompt=true "
+                "useTicketCache=true "
+                "useKeyTab=true;"
             ),
             "sasl.kerberos.service.name": "kafka",
         }
@@ -638,10 +628,9 @@ def test_kafka_kerberos_auth_no_keytab(spark_mock):
                 "com.sun.security.auth.module.Krb5LoginModule required "
                 'principal="user" '
                 'serviceName="kafka" '
-                "renewTicket=true "
-                "storeKey=true "
                 "useKeyTab=false "
-                "useTicketCache=true;"
+                "useTicketCache=true "
+                "doNotPrompt=true;"
             ),
             "sasl.kerberos.service.name": "kafka",
         }
@@ -668,11 +657,10 @@ def test_kafka_kerberos_auth_custom_jaas_conf_options(spark_mock, create_keytab)
             'principal="user" '
             f'keyTab="{create_keytab}" '
             'serviceName="kafka" '
-            "renewTicket=true "
-            "storeKey=true "
-            "useKeyTab=true "
-            "useTicketCache=false "
-            "debug=true;"
+            "debug=true "
+            "doNotPrompt=true "
+            "useTicketCache=true "
+            "useKeyTab=true;"
         ),
         "sasl.kerberos.service.name": "kafka",
     }
@@ -702,10 +690,9 @@ def test_kafka_kerberos_auth_custom_kafka_conf_options(spark_mock, create_keytab
             'principal="user" '
             f'keyTab="{create_keytab}" '
             'serviceName="kafka" '
-            "renewTicket=true "
-            "storeKey=true "
-            "useKeyTab=true "
-            "useTicketCache=false;"
+            "doNotPrompt=true "
+            "useTicketCache=true "
+            "useKeyTab=true;"
         ),
         "sasl.kerberos.service.name": "kafka",
         "sasl.kerberos.kinit.cmd": "/usr/bin/kinit",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

* There is no way in ETL processes to enter Kerberos password, so `storePass`, `tryFirstPass`, `useFirstPass`, `clearPass` are useless, and `doNotPrompt` should be true
* There is no `renewTicket` parameter, only `renewTGT`
* If user passed keytab file, set `useKeyTab=True`, otherwise pass `useTicketCache=True`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
