### PR TITLE
[DOP-39722] Add YAMLHWMStore(keep_history=True) flag

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,7 @@ pytest_plugins = [
     "tests.fixtures.processing.fixtures.kafka",
     "tests.fixtures.create_keytab",
     "tests.fixtures.global_hwm_store",
-    "tests.fixtures.hwm_delta",
+    "tests.fixtures.hwm_with_value",
     "tests.fixtures.spark_mock",
     "tests.fixtures.spark",
     "tests.fixtures.connections.base",

--- a/mddocs/docs/changelog/next_release/542.feature.md
+++ b/mddocs/docs/changelog/next_release/542.feature.md
@@ -1,0 +1,1 @@
+Add `YAMLHWMStore(keep_history=True)` flag.

--- a/onetl/hwm/store/yaml_hwm_store.py
+++ b/onetl/hwm/store/yaml_hwm_store.py
@@ -55,7 +55,6 @@ class YAMLHWMStore(BaseHWMStore):
     Parameters
     ----------
     path
-
         Folder name there HWM value files will be stored.
 
         Default:
@@ -65,8 +64,10 @@ class YAMLHWMStore(BaseHWMStore):
         * `~/Library/Application Support/onETL/yml_hwm_store` on MacOS
 
     encoding
-
         Encoding of files with HWM value
+
+    keep_history
+        Keep history of old HWM values in YAML file
 
     Examples
     --------
@@ -100,10 +101,11 @@ class YAMLHWMStore(BaseHWMStore):
     # "~/.local/share/onETL/id__public.mydata__postgres_postgres.domain.com_5432__myprocess__myhostname.yml"
     # with encoding="utf-8" and save a serialized HWM values to this file
     ```
+
     With all options
 
     ```python
-    with YAMLHWMStore(path="/my/store", encoding="utf-8"):
+    with YAMLHWMStore(path="/my/store", encoding="utf-8", keep_history=True):
         with IncrementalStrategy():
             df = reader.run()
             writer.run(df)
@@ -112,8 +114,8 @@ class YAMLHWMStore(BaseHWMStore):
     # "/my/store/id__public.mydata__postgres_postgres.domain.com_5432__myprocess__myhostname.yml"
     # with encoding="utf-8" and save a serialized HWM values to this file
     ```
-    File content example:
 
+    File content example:
     ```yaml
     - column:
         name: id
@@ -150,6 +152,7 @@ class YAMLHWMStore(BaseHWMStore):
 
     path: LocalPath = DATA_PATH / "yml_hwm_store"
     encoding: str = "utf-8"
+    keep_history: bool = True
 
     ITEMS_DELIMITER_PATTERN: ClassVar[re.Pattern] = re.compile("[#@|]+")
     PROHIBITED_SYMBOLS_PATTERN: ClassVar[re.Pattern] = re.compile(r"[=:/\\]+")
@@ -164,13 +167,20 @@ class YAMLHWMStore(BaseHWMStore):
             frozen = True
             extra = "forbid"
 
-    def __init__(self, path: os.PathLike | str = DATA_PATH / "yml_hwm_store", encoding="utf-8"):
+    def __init__(
+        self,
+        *,
+        path: os.PathLike | str = DATA_PATH / "yml_hwm_store",
+        encoding="utf-8",
+        keep_history: bool = True,
+    ):
         path = LocalPath(path).expanduser().resolve()
         path.mkdir(parents=True, exist_ok=True)
 
         super().__init__(
             path=path,
             encoding=encoding,
+            keep_history=keep_history,
         )
 
     @slot
@@ -188,7 +198,10 @@ class YAMLHWMStore(BaseHWMStore):
     def set_hwm(self, hwm: HWM) -> LocalPath:
         """Save HWM value. Returns path to the YAML file."""
         data = self._load(hwm.name)
-        self._dump(hwm.name, [hwm.serialize(), *data])
+        to_save: list[dict] = [hwm.serialize()]
+        if self.keep_history:
+            to_save.extend(data)
+        self._dump(hwm.name, to_save)
         return self.get_file_path(hwm.name)
 
     @classmethod

--- a/tests/fixtures/hwm_with_value.py
+++ b/tests/fixtures/hwm_with_value.py
@@ -1,5 +1,5 @@
 import secrets
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 from etl_entities.hwm import (
@@ -44,7 +44,7 @@ HWMS_WITH_VALUE = [
             expression=secrets.token_hex(5),
             value=date(year=2023, month=8, day=15),
         ),
-        timedelta(days=31),
+        date(year=2023, month=8, day=16),
     ),
     (
         ColumnDateTimeHWM(
@@ -53,7 +53,7 @@ HWMS_WITH_VALUE = [
             expression=secrets.token_hex(5),
             value=datetime(year=2023, month=8, day=15, hour=11, minute=22, second=33),
         ),
-        timedelta(seconds=50),
+        datetime(year=2023, month=8, day=15, hour=11, minute=22, second=43),
     ),
     (
         FileListHWM(
@@ -91,5 +91,5 @@ HWMS_WITH_VALUE = [
 
 
 @pytest.fixture(params=HWMS_WITH_VALUE)
-def hwm_delta(request):
+def hwm_with_value(request):
     return request.param

--- a/tests/tests_unit/tests_hwm_store_unit/test_yaml_hwm_store_unit.py
+++ b/tests/tests_unit/tests_hwm_store_unit/test_yaml_hwm_store_unit.py
@@ -7,6 +7,7 @@ import warnings
 from pathlib import Path
 
 import pytest
+import yaml
 from etl_entities.hwm_store import BaseHWMStore as OriginalBaseHWMStore
 from etl_entities.hwm_store import (
     HWMStoreClassRegistry as OriginalHWMStoreClassRegistry,
@@ -22,8 +23,9 @@ from etl_entities.hwm_store import (
 from onetl.hwm.store import YAMLHWMStore
 
 
-def test_hwm_store_yaml_path(request, tmp_path_factory, hwm_delta):
-    hwm, _delta = hwm_delta
+@pytest.mark.parametrize("keep_history", [True, False])
+def test_yaml_hwm_store(request, tmp_path_factory, hwm_with_value, keep_history):
+    hwm, new_value = hwm_with_value
     folder: Path = tmp_path_factory.mktemp("someconf")
     path = folder / secrets.token_hex(5)
 
@@ -32,7 +34,7 @@ def test_hwm_store_yaml_path(request, tmp_path_factory, hwm_delta):
 
     request.addfinalizer(finalizer)
 
-    store = YAMLHWMStore(path=path)
+    store = YAMLHWMStore(path=path, keep_history=keep_history)
 
     assert path.exists()
 
@@ -51,8 +53,16 @@ def test_hwm_store_yaml_path(request, tmp_path_factory, hwm_delta):
 
     assert store.get_hwm(hwm.name) == hwm
 
+    new_hwm = hwm.update(new_value)
+    store.set_hwm(new_hwm)
 
-def test_hwm_store_yaml_path_not_folder(request, tmp_path_factory):
+    assert store.get_hwm(hwm.name) == new_hwm
+
+    data = yaml.safe_load(item.read_text())
+    assert len(data) == 2 if keep_history else 1
+
+
+def test_yaml_hwm_store_path_not_folder(request, tmp_path_factory):
     folder: Path = tmp_path_factory.mktemp("someconf")
     path = folder / secrets.token_hex(5)
     path.touch()
@@ -68,8 +78,8 @@ def test_hwm_store_yaml_path_not_folder(request, tmp_path_factory):
 
 # TODO: fix
 @pytest.mark.skipif(sys.version_info >= (3, 14), reason="fails on Python 3.14")
-def test_hwm_store_yaml_path_no_access(request, tmp_path_factory, hwm_delta):
-    hwm, _delta = hwm_delta
+def test_yaml_hwm_store_path_no_access(request, tmp_path_factory, hwm_with_value):
+    hwm, _new_value = hwm_with_value
     folder: Path = tmp_path_factory.mktemp("someconf")
     path = folder / secrets.token_hex(5)
     path.mkdir()
@@ -90,7 +100,7 @@ def test_hwm_store_yaml_path_no_access(request, tmp_path_factory, hwm_delta):
         store.set_hwm(hwm)
 
 
-def test_hwm_store_yaml_context_manager(caplog):
+def test_yaml_hwm_store_context_manager(caplog):
     hwm_store = YAMLHWMStore()
 
     assert hwm_store.path
@@ -106,7 +116,7 @@ def test_hwm_store_yaml_context_manager(caplog):
     assert HWMStoreStackManager.get_current() == hwm_store
 
 
-def test_hwm_store_yaml_context_manager_with_path(caplog, request, tmp_path_factory):
+def test_yaml_hwm_store_context_manager_with_path(caplog, request, tmp_path_factory):
     folder: Path = tmp_path_factory.mktemp("someconf")
     path = folder / secrets.token_hex(5)
 
@@ -130,7 +140,7 @@ def test_hwm_store_yaml_context_manager_with_path(caplog, request, tmp_path_fact
     assert isinstance(HWMStoreStackManager.get_current(), YAMLHWMStore)
 
 
-def test_hwm_store_yaml_context_manager_with_encoding(caplog, request, tmp_path_factory):
+def test_yaml_hwm_store_context_manager_with_encoding(caplog, request, tmp_path_factory):
     folder: Path = tmp_path_factory.mktemp("someconf")
     path = folder / secrets.token_hex(5)
 
@@ -189,7 +199,7 @@ def test_hwm_store_yaml_context_manager_with_encoding(caplog, request, tmp_path_
         ),
     ],
 )
-def test_hwm_store_yaml_cleanup_file_name(qualified_name, file_name):
+def test_yaml_hwm_store_cleanup_file_name(qualified_name, file_name):
     assert YAMLHWMStore.cleanup_file_name(qualified_name) == file_name
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

By default, `YAMLHWMStore` keeps old values, which can rapidly increase file size. Added new option `keep_history` to disable this behavior.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MTSWebServices/onetl/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
